### PR TITLE
fixing archived onjar-maven-plugin groupId

### DIFF
--- a/ncoap-simple-client/pom.xml
+++ b/ncoap-simple-client/pom.xml
@@ -43,7 +43,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.dstovall</groupId>
+                <groupId>com.jolira</groupId>
                 <artifactId>onejar-maven-plugin</artifactId>
                 <version>1.4.4</version>
                 <executions>

--- a/ncoap-simple-server/pom.xml
+++ b/ncoap-simple-server/pom.xml
@@ -39,7 +39,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.dstovall</groupId>
+                <groupId>com.jolira</groupId>
                 <artifactId>onejar-maven-plugin</artifactId>
                 <version>1.4.4</version>
                 <executions>


### PR DESCRIPTION
org.dstovall ist nur noch im googlecode Archiv und die Dependency kann nicht aufgelöst werden.
https://code.google.com/archive/p/onejar-maven-plugin/source

Hier wurde die Dependency wieder verfügbar gemacht: https://github.com/jolira/onejar-maven-plugin
